### PR TITLE
Feature/physics asset viewer

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
@@ -180,7 +180,7 @@ void PhysicsAssetViewerPanel::LoadBoneIcon()
 void PhysicsAssetViewerPanel::CopyRefSkeleton()
 {
     UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
-    const FReferenceSkeleton& OrigRef = Engine->SkeletalMeshViewerWorld
+    const FReferenceSkeleton& OrigRef = Engine->PhysicsAssetViewerWorld
         ->GetSkeletalMeshComponent()->GetSkeletalMeshAsset()
         ->GetSkeleton()->GetReferenceSkeleton();
 
@@ -190,7 +190,7 @@ void PhysicsAssetViewerPanel::CopyRefSkeleton()
     CopiedRefSkeleton->InverseBindPoseMatrices = OrigRef.InverseBindPoseMatrices;
     CopiedRefSkeleton->RawNameToIndexMap = OrigRef.RawNameToIndexMap;
 
-    RefSkeletalMeshComponent = Engine->SkeletalMeshViewerWorld->GetSkeletalMeshComponent();
+    RefSkeletalMeshComponent = Engine->PhysicsAssetViewerWorld->GetSkeletalMeshComponent();
 }
 
 void PhysicsAssetViewerPanel::RenderBoneTree(const FReferenceSkeleton& RefSkeleton, int32 BoneIndex, UEditorEngine* Engine /*, const FString& SearchFilter */)
@@ -249,11 +249,11 @@ void PhysicsAssetViewerPanel::RenderBoneTree(const FReferenceSkeleton& RefSkelet
     bool bNodeOpen = ImGui::TreeNodeEx(*ShortBoneName, NodeFlags);
 
     // --- 클릭 이벤트 처리 ---
-    if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) // 왼쪽 마우스 버튼 클릭 시
-    {
-        // 엔진에 선택된 본 인덱스 설정 (가상의 함수 호출)
-        Engine->SkeletalMeshViewerWorld->SelectBoneIndex = (BoneIndex);
-    }
+    //if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) // 왼쪽 마우스 버튼 클릭 시
+    //{
+    //    // 엔진에 선택된 본 인덱스 설정 (가상의 함수 호출)
+    //    Engine->SkeletalMeshViewerWorld->SelectBoneIndex = (BoneIndex);
+    //}
 
     if (bNodeOpen) // 노드가 열려있다면
     {

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
@@ -37,10 +37,10 @@ void PhysicsAssetViewerPanel::Render()
     }
 
     /* Pre Setup */
-    float PanelWidth = (Width) * 0.2f - 6.0f;
-    float PanelHeight = (Height) * 0.7f;
+    float PanelWidth = (Width) * 0.2f - 5.0f;
+    float PanelHeight = (Height) * 0.9f;
 
-    float PanelPosX = (Width) * 0.8f + 5.0f;
+    float PanelPosX = 5.0f;
     float PanelPosY = 5.0f;
 
     ImVec2 MinSize(140, 100);

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.cpp
@@ -1,0 +1,298 @@
+#include "PhysicsAssetViewerPanel.h"
+
+#include "SkeletalMeshViewerPanel.h"
+#include "Engine/EditorEngine.h"
+#include <ReferenceSkeleton.h>
+
+// #include "Animation/AnimSequence.h"
+// #include "Animation/AnimSingleNodeInstance.h"
+// #include "Animation/AnimData/AnimDataModel.h"
+#include "Engine/Classes/Engine/SkeletalMesh.h"
+// #include "Engine/Classes/Animation/Skeleton.h"
+#include "Engine/Classes/Engine/FbxLoader.h"
+// #include "ThirdParty/ImGui/include/ImGui/imgui_neo_sequencer.h"
+#include "Engine/Classes/Components/SkeletalMeshComponent.h"
+// #include "Engine/Classes/Animation/AnimTypes.h"
+#include "UnrealEd/ImGuiWidget.h"
+// #include "Contents/AnimInstance/MyAnimInstance.h"
+// #include "Animation/AnimSoundNotify.h"
+// #include "SoundManager.h"
+
+
+PhysicsAssetViewerPanel::PhysicsAssetViewerPanel()
+{
+    SetSupportedWorldTypes(EWorldTypeBitFlag::PhysicsAssetViewer);
+}
+
+void PhysicsAssetViewerPanel::Render()
+{
+    UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
+    if (!Engine)
+    {
+        return;
+    }
+
+    if (BoneIconSRV == nullptr || NonWeightBoneIconSRV == nullptr) {
+        LoadBoneIcon();
+    }
+
+    /* Pre Setup */
+    float PanelWidth = (Width) * 0.2f - 6.0f;
+    float PanelHeight = (Height) * 0.7f;
+
+    float PanelPosX = (Width) * 0.8f + 5.0f;
+    float PanelPosY = 5.0f;
+
+    ImVec2 MinSize(140, 100);
+    ImVec2 MaxSize(FLT_MAX, 1000);
+
+    /* Min, Max Size */
+    ImGui::SetNextWindowSizeConstraints(MinSize, MaxSize);
+    /* Panel Position */
+    ImGui::SetNextWindowPos(ImVec2(PanelPosX, PanelPosY), ImGuiCond_Always);
+
+    /* Panel Size */
+    ImGui::SetNextWindowSize(ImVec2(PanelWidth, PanelHeight), ImGuiCond_Always);
+
+    constexpr ImGuiWindowFlags PanelFlags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_HorizontalScrollbar;
+
+
+    if (Engine->ActiveWorld) {
+        if (Engine->ActiveWorld->WorldType == EWorldType::PhysicsAssetViewer) {
+
+            if (CopiedRefSkeleton == nullptr) {
+                CopyRefSkeleton(); // 선택된 액터/컴포넌트로부터 스켈레톤 정보 복사
+            }
+
+            // CopiedRefSkeleton이 여전히 null이면 렌더링하지 않음
+            if (CopiedRefSkeleton == nullptr || CopiedRefSkeleton->RawRefBoneInfo.IsEmpty()) {
+                ImGui::Begin("Bone Hierarchy", nullptr, PanelFlags); // 창은 표시하되 내용은 비움
+                ImGui::Text("No skeleton selected or skeleton has no bones.");
+                ImGui::End();
+                return;
+            }
+
+            ImGui::Begin("Bone Hierarchy", nullptr, PanelFlags); // 창 이름 변경
+
+            // 검색 필터 추가 (선택 사항)
+            // static char BoneSearchText[128] = "";
+            // ImGui::InputText("Search", BoneSearchText, IM_ARRAYSIZE(BoneSearchText));
+            // FString SearchFilter(BoneSearchText);
+
+            // 루트 본부터 시작하여 트리 렌더링
+            for (int32 i = 0; i < CopiedRefSkeleton->RawRefBoneInfo.Num(); ++i)
+            {
+                if (CopiedRefSkeleton->RawRefBoneInfo[i].ParentIndex == INDEX_NONE) // 루트 본인 경우
+                {
+                    // RenderBoneTree 호출 시 Engine 포인터 전달
+                    RenderBoneTree(*CopiedRefSkeleton, i, Engine /*, SearchFilter */);
+                }
+            }
+            ImGui::End();
+        }
+
+        // RenderAnimationPanel(PanelPosX, PanelPosY, PanelWidth, PanelHeight);
+
+        //if (CopiedRefSkeleton) {
+        //    RenderAnimationSequence(*CopiedRefSkeleton, Engine);
+        //}
+
+        float ExitPanelWidth = (Width) * 0.2f - 6.0f;
+        float ExitPanelHeight = 30.0f;
+
+        const float margin = 10.0f;
+
+        float ExitPanelPosX = Width - ExitPanelWidth;
+        float ExitPanelPosY = Height - ExitPanelHeight - 10;
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
+
+        ImGui::SetNextWindowSize(ImVec2(ExitPanelWidth, ExitPanelHeight), ImGuiCond_Always);
+        ImGui::SetNextWindowPos(ImVec2(ExitPanelPosX, ExitPanelPosY), ImGuiCond_Always);
+
+        constexpr ImGuiWindowFlags ExitPanelFlags =
+            ImGuiWindowFlags_NoResize
+            | ImGuiWindowFlags_NoMove
+            | ImGuiWindowFlags_NoTitleBar
+            | ImGuiWindowFlags_NoBackground
+            | ImGuiWindowFlags_NoScrollbar;
+
+        ImGui::Begin("Exit Viewer", nullptr, ExitPanelFlags);
+        if (ImGui::Button("Exit Viewer", ImVec2(ExitPanelWidth, ExitPanelHeight))) {
+            ClearRefSkeletalMeshComponent();
+            UEditorEngine* EdEngine = Cast<UEditorEngine>(GEngine);
+            EdEngine->EndSkeletalMeshViewer();
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+    }
+}
+
+void PhysicsAssetViewerPanel::OnResize(HWND hWnd)
+{
+    RECT ClientRect;
+    GetClientRect(hWnd, &ClientRect);
+    Width = ClientRect.right - ClientRect.left;
+    Height = ClientRect.bottom - ClientRect.top;
+}
+
+void PhysicsAssetViewerPanel::SetSkeletalMesh(USkeletalMesh* SMesh)
+{
+    SkeletalMesh = SMesh;
+}
+
+int32 PhysicsAssetViewerPanel::GetSelectedBoneIndex() const
+{
+    return SelectedBoneIndex;
+}
+
+FString PhysicsAssetViewerPanel::GetSelectedBoneName() const
+{
+    if (SelectedBoneIndex == INDEX_NONE || !SkeletalMesh)
+        return TEXT("");
+    const auto& RefSkel = SkeletalMesh->GetSkeleton()->GetReferenceSkeleton();
+    return RefSkel.RawRefBoneInfo[SelectedBoneIndex].Name.ToString();
+}
+
+void PhysicsAssetViewerPanel::ClearRefSkeletalMeshComponent()
+{
+    if (RefSkeletalMeshComponent)
+    {
+        RefSkeletalMeshComponent = nullptr;
+    }
+    if (CopiedRefSkeleton)
+    {
+        CopiedRefSkeleton = nullptr;
+    }
+    //if (PrevAnimDataModel)
+    //{
+    //    PrevAnimDataModel = nullptr;
+    //}
+}
+
+void PhysicsAssetViewerPanel::LoadBoneIcon()
+{
+    BoneIconSRV = FEngineLoop::ResourceManager.GetTexture(L"Assets/Viewer/Bone_16x.PNG")->TextureSRV;
+    NonWeightBoneIconSRV = FEngineLoop::ResourceManager.GetTexture(L"Assets/Viewer/BoneNonWeighted_16x.PNG")->TextureSRV;
+
+}
+
+void PhysicsAssetViewerPanel::CopyRefSkeleton()
+{
+    UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
+    const FReferenceSkeleton& OrigRef = Engine->SkeletalMeshViewerWorld
+        ->GetSkeletalMeshComponent()->GetSkeletalMeshAsset()
+        ->GetSkeleton()->GetReferenceSkeleton();
+
+    CopiedRefSkeleton = new FReferenceSkeleton();
+    CopiedRefSkeleton->RawRefBoneInfo = OrigRef.RawRefBoneInfo;
+    CopiedRefSkeleton->RawRefBonePose = OrigRef.RawRefBonePose;
+    CopiedRefSkeleton->InverseBindPoseMatrices = OrigRef.InverseBindPoseMatrices;
+    CopiedRefSkeleton->RawNameToIndexMap = OrigRef.RawNameToIndexMap;
+
+    RefSkeletalMeshComponent = Engine->SkeletalMeshViewerWorld->GetSkeletalMeshComponent();
+}
+
+void PhysicsAssetViewerPanel::RenderBoneTree(const FReferenceSkeleton& RefSkeleton, int32 BoneIndex, UEditorEngine* Engine /*, const FString& SearchFilter */)
+{
+    const FMeshBoneInfo& BoneInfo = CopiedRefSkeleton->RawRefBoneInfo[BoneIndex];
+    const FString& ShortBoneName = GetCleanBoneName(BoneInfo.Name.ToString());
+
+    // 검색 필터 적용 (선택 사항)
+    // if (!SearchFilter.IsEmpty() && !ShortBoneName.Contains(SearchFilter))
+    // {
+    //    // 자식도 검색해야 하므로, 현재 노드가 필터에 맞지 않아도 자식은 재귀 호출
+    //    bool bChildMatchesFilter = false;
+    //    for (int32 i = 0; i < RefSkeleton.RawRefBoneInfo.Num(); ++i)
+    //    {
+    //        if (RefSkeleton.RawRefBoneInfo[i].ParentIndex == BoneIndex)
+    //        {
+    //            // 자식 중 하나라도 필터에 맞으면 현재 노드도 표시해야 할 수 있음 (복잡해짐)
+    //            // 간단하게는 현재 노드가 안 맞으면 그냥 건너뛰도록 할 수 있음
+    //        }
+    //    }
+    //    // 간단한 필터링: 현재 노드가 안 맞으면 그냥 숨김 (자식도 안 나옴)
+    //    // if (!ShortBoneName.Contains(SearchFilter)) return;
+    // }
+
+    // 1) ImGui ID 충돌 방지
+    ImGui::PushID(BoneIndex);
+
+    ImGui::Image((ImTextureID)BoneIconSRV, ImVec2(16, 16));  // 16×16 픽셀 크기
+    ImGui::SameLine();
+
+    ImGuiTreeNodeFlags NodeFlags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen;
+    // if (Engine->SkeletalMeshViewerWorld->SelectBoneIndex == BoneIndex) // 가상의 함수 호출
+    // {
+    //     NodeFlags |= ImGuiTreeNodeFlags_Selected; // 선택된 경우 Selected 플래그 추가
+    // }
+
+    // 자식이 없는 본은 리프 노드로 처리 (화살표 없음)
+    bool bHasChildren = false;
+    for (int32 i = 0; i < RefSkeleton.RawRefBoneInfo.Num(); ++i)
+    {
+        if (RefSkeleton.RawRefBoneInfo[i].ParentIndex == BoneIndex)
+        {
+            bHasChildren = true;
+            break;
+        }
+    }
+    if (!bHasChildren)
+    {
+        NodeFlags |= ImGuiTreeNodeFlags_Leaf; // 자식 없으면 리프 노드
+        NodeFlags &= ~ImGuiTreeNodeFlags_OpenOnArrow; // 리프 노드는 화살표로 열 필요 없음
+    }
+
+    // ImGui::TreeNodeEx (본 이름, 플래그)
+    // 이름 부분만 클릭 가능하도록 하려면 ImGui::Selectable을 함께 사용하거나 커스텀 로직 필요
+    // 여기서는 TreeNodeEx 자체의 클릭 이벤트를 사용
+    bool bNodeOpen = ImGui::TreeNodeEx(*ShortBoneName, NodeFlags);
+
+    // --- 클릭 이벤트 처리 ---
+    if (ImGui::IsItemClicked(ImGuiMouseButton_Left)) // 왼쪽 마우스 버튼 클릭 시
+    {
+        // 엔진에 선택된 본 인덱스 설정 (가상의 함수 호출)
+        Engine->SkeletalMeshViewerWorld->SelectBoneIndex = (BoneIndex);
+    }
+
+    if (bNodeOpen) // 노드가 열려있다면
+    {
+        // 자식 본들 재귀적으로 처리
+        for (int32 i = 0; i < RefSkeleton.RawRefBoneInfo.Num(); ++i)
+        {
+            if (RefSkeleton.RawRefBoneInfo[i].ParentIndex == BoneIndex)
+            {
+                RenderBoneTree(RefSkeleton, i, Engine /*, SearchFilter */); // 재귀 호출 시 Engine 전달
+            }
+        }
+        ImGui::TreePop(); // 트리 노드 닫기
+    }
+    ImGui::PopID(); // ID 스택 복원
+}
+
+// void PhysicsAssetViewerPanel::RenderAnimationSequence(const FReferenceSkeleton& RefSkeleton, UEditorEngine* Engine)
+
+FString PhysicsAssetViewerPanel::GetCleanBoneName(const FString& InFullName)
+{
+    // 1) 계층 구분자 '|' 뒤 이름만 취하기
+    int32 barIdx = InFullName.FindChar(TEXT('|'),
+        /*case*/ ESearchCase::CaseSensitive,
+        /*dir*/  ESearchDir::FromEnd);
+    FString name = (barIdx != INDEX_NONE)
+        ? InFullName.RightChop(barIdx + 1)
+        : InFullName;
+
+    // 2) 네임스페이스 구분자 ':' 뒤 이름만 취하기
+    int32 colonIdx = name.FindChar(TEXT(':'),
+        /*case*/ ESearchCase::CaseSensitive,
+        /*dir*/  ESearchDir::FromEnd);
+    if (colonIdx != INDEX_NONE)
+    {
+        return name.RightChop(colonIdx + 1);
+    }
+    return name;
+}
+
+//void SkeletalMeshViewerPanel::RenderAnimationPanel(float PanelPosX, float PanelPosY, float PanelWidth, float PanelHeight)
+
+

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "Engine/EditorEngine.h"
+#include "GameFramework/Actor.h"
+#include "UnrealEd/EditorPanel.h"
+
+class USkeletalMesh;
+class FReferenceSkeleton;
+class USkeletalMeshComponent;
+// class UAnimDataModel;
+
+class PhysicsAssetViewerPanel : public UEditorPanel
+{
+public:
+    PhysicsAssetViewerPanel();
+
+    virtual void Render() override;
+    virtual void OnResize(HWND hWnd) override;
+
+    void SetSkeletalMesh(USkeletalMesh * SMesh);
+
+    int32 GetSelectedBoneIndex() const;
+    FString GetSelectedBoneName() const;
+
+    void ClearRefSkeletalMeshComponent();
+private:
+    float Width = 0, Height = 0;
+    USkeletalMesh* SkeletalMesh;
+
+    void LoadBoneIcon();
+    void CopyRefSkeleton();
+
+    void RenderBoneTree(const FReferenceSkeleton & RefSkeleton, int32 BoneIndex, UEditorEngine * Engine);
+
+    // void RenderAnimationSequence(const FReferenceSkeleton & RefSkeleton, UEditorEngine * Engine); // 
+    // void RenderAnimationPanel(float PanelPosX, float PanelTopY, float PanelWidth, float PanelHeight);
+    FString GetCleanBoneName(const FString & InFullName);
+
+    ID3D11ShaderResourceView* BoneIconSRV = nullptr;
+    ID3D11ShaderResourceView* NonWeightBoneIconSRV = nullptr;
+
+    int32 SelectedBoneIndex = INDEX_NONE;
+
+    FReferenceSkeleton* CopiedRefSkeleton = nullptr;
+    USkeletalMeshComponent* RefSkeletalMeshComponent = nullptr;
+
+    //UAnimDataModel* PrevAnimDataModel = nullptr;
+
+    //int32 PreviousFrame = 0;
+    //int32 SelectedTrackIndex_ForRename = INDEX_NONE;
+    //int32 SelectedNotifyGlobalIndex_ForRename = INDEX_NONE;
+    //TCHAR RenameTrackBuffer[256];
+    //TCHAR RenameNotifyBuffer[256];
+
+//private:
+//    char NewNotifyNameBuffer[128] = "NewNotify";
+//    float NewNotifyTime = 0.0f;
+//    float RenameNotifyDuration = 1.0f;
+
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PhysicsAssetViewerPanel.h
@@ -2,6 +2,7 @@
 #include "Engine/EditorEngine.h"
 #include "GameFramework/Actor.h"
 #include "UnrealEd/EditorPanel.h"
+#include "PhysicsEngine/ConstraintInstance.h"
 
 class USkeletalMesh;
 class FReferenceSkeleton;
@@ -22,6 +23,10 @@ public:
     FString GetSelectedBoneName() const;
 
     void ClearRefSkeletalMeshComponent();
+
+    void AddConstraint(const FString& BoneName1, const FString& BoneName2);
+    void RemoveConstraint(int32 ConstraintIndex);
+
 private:
     float Width = 0, Height = 0;
     USkeletalMesh* SkeletalMesh;
@@ -51,7 +56,8 @@ private:
     //TCHAR RenameTrackBuffer[256];
     //TCHAR RenameNotifyBuffer[256];
 
-//private:
+private:
+    TArray<FConstraintInstance> Constraints; // 물리 제약 조건 인스턴스 배열
 //    char NewNotifyNameBuffer[128] = "NewNotify";
 //    float NewNotifyTime = 0.0f;
 //    float RenameNotifyDuration = 1.0f;

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/UnrealEd.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/UnrealEd.cpp
@@ -6,6 +6,7 @@
 #include "PropertyEditor/ParticleViewerPanel.h"
 #include "PropertyEditor/PropertyEditorPanel.h"
 #include "PropertyEditor/SkeletalMeshViewerPanel.h"
+#include "PropertyEditor/PhysicsAssetViewerPanel.h"
 #include "World/World.h"
 void UnrealEd::Initialize()
 {
@@ -20,10 +21,13 @@ void UnrealEd::Initialize()
 
     // TODO : SkeletalViewe 전용 UI 분리
     auto BoneHierarchyPanel = std::make_shared<SkeletalMeshViewerPanel>();
-    Panels["BoneHierarchyPaenl"] = BoneHierarchyPanel;
+    Panels["BoneHierarchyPanel"] = BoneHierarchyPanel;
     
     auto ParticleViewPanel = std::make_shared<ParticleViewerPanel>();
     Panels["ParticleViewerPanel"] = ParticleViewPanel;
+
+    auto PhysicsAssetPanel = std::make_shared<PhysicsAssetViewerPanel>();
+    Panels["PhysicsAssetViewerPanel"] = PhysicsAssetPanel;
 }
 
 void UnrealEd::Render() const
@@ -54,6 +58,9 @@ void UnrealEd::Render() const
         break;
     case EWorldType::ParticleViewer:
         currentMask = EWorldTypeBitFlag::ParticleViewer;
+        break;
+    case EWorldType::PhysicsAssetViewer:
+        currentMask = EWorldTypeBitFlag::PhysicsAssetViewer;
         break;
     case EWorldType::Inactive:
         currentMask = EWorldTypeBitFlag::Inactive;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/PhysicsEngine/ConstraintInstance.cpp
@@ -1,1 +1,5 @@
-﻿#include "ConstraintInstance.h"
+#include "ConstraintInstance.h"
+
+FConstraintInstance::FConstraintInstance()
+{
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/World/WorldType.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/World/WorldType.h
@@ -27,7 +27,8 @@ enum class EWorldTypeBitFlag
     GameRPC = 1 << 5,
     SkeletalViewer = 1 << 6,
     ParticleViewer = 1 << 7,
-    Inactive = 1 << 8
+    PhysicsAssetViewer = 1 << 8,  
+    Inactive = 1 << 9   
 };
 
 inline EWorldTypeBitFlag operator|(EWorldTypeBitFlag A, EWorldTypeBitFlag B)


### PR DESCRIPTION
## 주요 변경사항
 
SkeletalMeshActor 를 생성하고 우측 Detail panel 에서 Physics Asset 토글 -> Open Viewer 를 선택했을 때 새로운 Physics Asset Editor(Viewer) 전용 window 를 열고 skeletal 을 render 하고 bone hierarcy 구조를 보여주는 로직 추가. 
    - UEditorPanel 을 상속받는 PhysicsAssetViewerPanel Class를 추가
    -  EWorldTypeBitFlag 에 PhysicsAssetViewer 를 추가
    -  PhysicsAssetViewerPanel 에 우클릭 Add Constraint 버튼 로직 추가.
    -  Animation 관련 함수는 주석처리.
    -  PhysicsAssetViewer 에서 Bone Hierarcy 좌측으로 UI변경
    -  PhysicsAssetViewerPanel 에 우클릭 Add Constraint 버튼 로직 추가.
    -  UnrealEd.cpp 에 UnrealEd::Initialize() 에 PhysicsAssetPanel 추가, BoneHierarchyPaenl 오타 수정
    -  UnrealEd::Renderr 에 case EWorldType::PhysicsASsetViewer 추가.

Todo: Physics Asset Viewer 에서 viewport 가 좌측끝부터 우측 중간지점까지 위치하고 있음. 좌측 끝에 Bone Hierarcy Panel 이 오버랩 되어 viewport 좌측 일부가 가려지는 문제 개선 필요. 