### PR TITLE
Feat/particle save load

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.cpp
@@ -790,25 +790,16 @@ void PropertyEditorPanel::RenderForPhysicsAsset(const USkeletalMeshComponent* Sk
     ImGui::PopStyleColor();
 }
 
-void PropertyEditorPanel::RenderForParticleSystem(UParticleSystemComponent* ParticleSystemComponent) const
+void PropertyEditorPanel::RenderForParticleSystem(const UParticleSystemComponent* ParticleSystemComponent) const
 {
     if (ImGui::Button("Open Viewer"))
     {
         UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
-        if (!Engine)
-        {
-            return;
-        }
-        if (ParticleSystemComponent)
+        if (Engine && ParticleSystemComponent)
         {
             UParticleSystem* ParticleSystem = ParticleSystemComponent->GetParticleSystem();
-            if (ParticleSystem == nullptr)
-            {
-                ParticleSystem = FObjectFactory::ConstructObject<UParticleSystem>(nullptr);
-                UAssetManager::Get().AddAsset(ParticleSystem->GetName(), ParticleSystem);
-                ParticleSystemComponent->SetParticleSystem(ParticleSystem);
-            }
-            Engine->StartParticleViewer(FName("TempParticle"), ParticleSystem);
+            FName AssetName = UAssetManager::Get().GetAssetKeyByObject(EAssetType::ParticleSystem, ParticleSystem);
+            Engine->StartParticleViewer(AssetName);
         }
     }
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/PropertyEditorPanel.h
@@ -66,7 +66,7 @@ private:
     void RenderForStaticMesh(UStaticMeshComponent* StaticMeshComp) const;
     void RenderForSkeletalMesh(USkeletalMeshComponent* SkeletalMeshComp) const;
     void RenderForPhysicsAsset(const USkeletalMeshComponent* SkeletalMeshComp) const;
-    void RenderForParticleSystem(UParticleSystemComponent* ParticleSystemComponent) const;
+    void RenderForParticleSystem(const UParticleSystemComponent* ParticleSystemComponent) const;
 
     void RenderForAmbientLightComponent(UAmbientLightComponent* AmbientLightComponent) const;
     void RenderForDirectionalLightComponent(UDirectionalLightComponent* DirectionalLightComponent) const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/ArrayHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/ArrayHelper.h
@@ -7,7 +7,7 @@
 struct FArrayHelper
 {
     template <typename T, typename AllocatorType>
-    static void SerializePtrAsset(FArchive& Ar, TArray<T, AllocatorType>& Array)
+    static void SerializePtrAsset(FArchive& Ar, TArray<T, AllocatorType>& Array, UObject* Outer = nullptr)
     {
         static_assert(std::is_pointer_v<T>, "T must be a pointer type for SerializePtrAsset.");
     
@@ -47,7 +47,7 @@ struct FArrayHelper
             {
                 if constexpr (bIsUObject)
                 {
-                    ActualClassName = PointerToType::StaticClass()->GetFName();
+                    ActualClassName = Array.ContainerPrivate[Index]->GetClass()->GetFName();
                 }
             }
             
@@ -58,7 +58,7 @@ struct FArrayHelper
                 if constexpr (bIsUObject)
                 {
                     UClass* ActualClass = UClass::FindClass(ActualClassName);
-                    Array.ContainerPrivate[Index] = Cast<PointerToType>(FObjectFactory::ConstructObject(ActualClass, nullptr));
+                    Array.ContainerPrivate[Index] = Cast<PointerToType>(FObjectFactory::ConstructObject(ActualClass, Outer));
                 }
                 else
                 {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/ArrayHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/ArrayHelper.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "Array.h"
 #include "Serialization/Archive.h"
+#include "UObject/Casts.h"
 #include "UObject/ObjectFactory.h"
 
 struct FArrayHelper
@@ -12,13 +13,15 @@ struct FArrayHelper
     
         using PointerToType = std::remove_pointer_t<T>;
         using SizeType = typename TArray<T, AllocatorType>::SizeType;
+        constexpr bool bIsUObject = std::is_base_of_v<UObject, PointerToType>;
     
         uint32 ArraySize = static_cast<uint32>(Array.Num());
         Ar << ArraySize;
 
         if (Ar.IsLoading())
         {
-            if constexpr (std::is_base_of_v<UObject, PointerToType>)
+            // 기존에 존재하던 원소 모두 제거
+            if constexpr (bIsUObject)
             {
                 for (SizeType Index = 0; Index < Array.Num(); ++Index)
                 {
@@ -39,14 +42,27 @@ struct FArrayHelper
 
         for (SizeType Index = 0; Index < ArraySize; ++Index)
         {
+            FName ActualClassName = NAME_None;
+            if (Ar.IsSaving())
+            {
+                if constexpr (bIsUObject)
+                {
+                    ActualClassName = PointerToType::StaticClass()->GetFName();
+                }
+            }
+            
+            Ar << ActualClassName;
+            
             if (Ar.IsLoading())
             {
-                if constexpr (std::is_base_of_v<UObject, PointerToType>)
+                if constexpr (bIsUObject)
                 {
-                    Array.ContainerPrivate[Index] = FObjectFactory::ConstructObject<PointerToType>(nullptr);
+                    UClass* ActualClass = UClass::FindClass(ActualClassName);
+                    Array.ContainerPrivate[Index] = Cast<PointerToType>(FObjectFactory::ConstructObject(ActualClass, nullptr));
                 }
                 else
                 {
+                    // TODO: UObject를 상속하지 않는 타입은 어떻게 처리해야할지 생각해봐야 함.
                     Array.ContainerPrivate[Index] = new PointerToType();
                 }
             }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
@@ -492,6 +492,11 @@ const TArray<FOverlapInfo>& UPrimitiveComponent::GetOverlapInfos() const
 
 void UPrimitiveComponent::CreatePhysXGameObject()
 {
+    if (!bSimulate)
+    {
+        return;
+    }
+    
     BodyInstance = new FBodyInstance(this);
     
     FVector Location = GetComponentLocation();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distribution/DistributionFloat.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distribution/DistributionFloat.h
@@ -16,4 +16,9 @@ struct FDistributionFloat
 
     void GetOutRange(float& MinOut, float& MaxOut);
     float GetValue();
+
+    friend FArchive& operator<<(FArchive& Ar, FDistributionFloat& DF)
+    {
+        return Ar << DF.MinValue << DF.MaxValue;
+    }
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distribution/DistributionVector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distribution/DistributionVector.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <algorithm>
+
 #include "Math/Vector.h"
 #include "UObject/ObjectMacros.h"
 
@@ -41,9 +43,9 @@ public:
 
     void UpdateDistributionParam()
     {
-        if (MinValue.X > MaxValue.X) MaxValue.X = MinValue.X;
-        if (MinValue.Y > MaxValue.Y) MaxValue.Y = MinValue.Y;
-        if (MinValue.Z > MaxValue.Z) MaxValue.Z = MinValue.Z;
+        MaxValue.X = FMath::Max(MinValue.X, MaxValue.X);
+        MaxValue.Y = FMath::Max(MinValue.Y, MaxValue.Y);
+        MaxValue.Z = FMath::Max(MinValue.Z, MaxValue.Z);
 
         DistX = std::uniform_real_distribution<float>(MinValue.X, MaxValue.X);
         DistY = std::uniform_real_distribution<float>(MinValue.Y, MaxValue.Y);
@@ -62,10 +64,18 @@ public:
     {
         UpdateDistributionParam();
 
-        return FVector(
-            DistX(Gen),
-            DistY(Gen),
-            DistZ(Gen)
-        );
+        return FVector(DistX(Gen), DistY(Gen), DistZ(Gen));
+    }
+
+    friend FArchive& operator<<(FArchive& Ar, FDistributionVector& DV)
+    {
+        Ar << DV.MinValue << DV.MaxValue;
+
+        if (Ar.IsLoading())
+        {
+            DV.UpdateDistributionParam();
+        }
+
+        return Ar;
     }
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
@@ -62,7 +62,18 @@ void UAssetManager::ReleaseAssetManager()
             }
         }
     }
-    
+
+    for (auto& [Key, AssetObject] : AssetMap[EAssetType::ParticleSystem])
+    {
+        const FAssetInfo& Info = AssetRegistry->PathNameToAssetInfo[Key];
+        if (Info.AssetObject)
+        {
+            if (UParticleSystem* ParticleSystemAsset = Cast<UParticleSystem>(Info.AssetObject))
+            {
+                SaveParticleSystemAsset(Info.GetFullPath(), ParticleSystemAsset);
+            }
+        }
+    }
 }
 
 const TMap<FName, FAssetInfo>& UAssetManager::GetAssetRegistry()
@@ -136,11 +147,14 @@ void UAssetManager::GetAssetKeys(EAssetType AssetType, TArray<FName>& OutKeys) c
 
 const FName& UAssetManager::GetAssetKeyByObject(EAssetType AssetType, const UObject* AssetObject) const
 {
-    for (const auto& [Key, Object] : AssetMap[AssetType])
+    if (AssetObject)
     {
-        if (Object == AssetObject)
+        for (const auto& [Key, Object] : AssetMap[AssetType])
         {
-            return Key;
+            if (Object == AssetObject)
+            {
+                return Key;
+            }
         }
     }
     return NAME_None;
@@ -175,6 +189,49 @@ bool UAssetManager::SavePhysicsAsset(const FString& FilePath, UPhysicsAsset* Phy
 
     SerializeVersion(Writer);
     PhysicsAsset->SerializeAsset(Writer);
+
+    std::ofstream OutputStream{ Path, std::ios::binary | std::ios::trunc };
+    if (!OutputStream.is_open())
+    {
+        std::filesystem::path ParentPath = Path.parent_path();
+        try
+        {
+            std::filesystem::create_directory(ParentPath);
+        }
+        catch (const std::filesystem::filesystem_error& e)
+        {
+            return false;
+        }
+    }
+
+    if (SaveData.Num() > 0)
+    {
+        OutputStream.write(reinterpret_cast<const char*>(SaveData.GetData()), SaveData.Num());
+
+        if (OutputStream.fail())
+        {
+            return false;
+        }
+    }
+
+    OutputStream.close();
+    return true;
+}
+
+bool UAssetManager::SaveParticleSystemAsset(const FString& FilePath, UParticleSystem* ParticleSystemAsset)
+{
+    if (!ParticleSystemAsset)
+    {
+        return false;
+    }
+    
+    std::filesystem::path Path = (FilePath + ".particlesystem").ToWideString();
+
+    TArray<uint8> SaveData;
+    FMemoryWriter Writer(SaveData);
+
+    SerializeVersion(Writer);
+    ParticleSystemAsset->SerializeAsset(Writer);
 
     std::ofstream OutputStream{ Path, std::ios::binary | std::ios::trunc };
     if (!OutputStream.is_open())
@@ -247,6 +304,7 @@ void UAssetManager::LoadContentFiles()
     TArray<std::filesystem::directory_entry> ObjEntries;
     TArray<std::filesystem::directory_entry> FbxEntries;
     TArray<std::filesystem::directory_entry> PhysicsAssetEntries;
+    TArray<std::filesystem::directory_entry> ParticleSystemEntries;
 
     for (const auto& Entry : std::filesystem::recursive_directory_iterator(BasePathName))
     {
@@ -266,6 +324,10 @@ void UAssetManager::LoadContentFiles()
         else if (Entry.path().extension() == ".physicsasset")
         {
             PhysicsAssetEntries.Add(Entry);
+        }
+        else if (Entry.path().extension() == ".particlesystem")
+        {
+            ParticleSystemEntries.Add(Entry);
         }
     }
 
@@ -313,6 +375,25 @@ void UAssetManager::LoadContentFiles()
         AssetInfo.Size = static_cast<uint32>(std::filesystem::file_size(Entry.path()));
 
         HandlePhysicsAsset(AssetInfo);
+    }
+
+    for (const auto& Entry : ParticleSystemEntries)
+    {
+        FString FileName = Entry.path().filename().generic_string();
+        int32 DotIdx = FileName.FindChar('.', ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+        if (DotIdx != INDEX_NONE)
+        {
+            FileName = FileName.Left(DotIdx);
+        }
+        
+        FAssetInfo AssetInfo = {};
+        AssetInfo.AssetName = FName(FileName);
+        AssetInfo.PackagePath = FName(Entry.path().parent_path().generic_string());
+        AssetInfo.SourceFilePath = Entry.path().generic_string();
+        AssetInfo.AssetType = EAssetType::ParticleSystem;
+        AssetInfo.Size = static_cast<uint32>(std::filesystem::file_size(Entry.path()));
+
+        HandleParticleSystemAsset(AssetInfo);
     }
 }
 
@@ -622,6 +703,57 @@ void UAssetManager::HandlePhysicsAsset(FAssetInfo& AssetInfo)
     {
         PreviewMesh->SetPhysicsAsset(PhysicsAsset);
     }
+}
+
+void UAssetManager::HandleParticleSystemAsset(FAssetInfo& AssetInfo)
+{
+    TArray<uint8> LoadData;
+    {
+        std::ifstream InputStream{ *AssetInfo.SourceFilePath, std::ios::binary | std::ios::ate };
+        if (!InputStream.is_open())
+        {
+            return;
+        }
+
+        const std::streamsize FileSize = InputStream.tellg();
+        if (FileSize < 0)
+        {
+            // Error getting size
+            InputStream.close();
+            return;
+        }
+        if (FileSize == 0)
+        {
+            // Empty file is valid
+            InputStream.close();
+            return; // Buffer remains empty
+        }
+
+        InputStream.seekg(0, std::ios::beg);
+
+        LoadData.SetNum(static_cast<int32>(FileSize));
+        InputStream.read(reinterpret_cast<char*>(LoadData.GetData()), FileSize);
+
+        if (InputStream.fail() || InputStream.gcount() != FileSize)
+        {
+            return;
+        }
+        InputStream.close();
+    }
+
+    FMemoryReader Reader(LoadData);
+    
+    if (!SerializeVersion(Reader))
+    {
+        return;
+    }
+    
+    UParticleSystem* ParticleSystemAsset = FObjectFactory::ConstructObject<UParticleSystem>(nullptr, AssetInfo.AssetName);
+    ParticleSystemAsset->SerializeAsset(Reader);
+    
+    AssetInfo.AssetObject = ParticleSystemAsset;
+    AddAsset(AssetInfo.GetFullPath(), ParticleSystemAsset);
+    AddAssetInfo(AssetInfo);
 }
 
 bool UAssetManager::SerializeVersion(FArchive& Ar)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.h
@@ -107,6 +107,8 @@ public:
 
     bool SavePhysicsAsset(const FString& FilePath, UPhysicsAsset* PhysicsAsset);
 
+    bool SaveParticleSystemAsset(const FString& FilePath, UParticleSystem* ParticleSystemAsset);
+
 private:
     inline static TMap<EAssetType, TMap<FName, UObject*>> AssetMap;
     
@@ -126,6 +128,8 @@ private:
     bool SaveFbxBinary(const FString& FilePath, FAssetLoadResult& Result, const FString& BaseName, const FString& FolderPath);
 
     void HandlePhysicsAsset(FAssetInfo& AssetInfo);
+
+    void HandleParticleSystemAsset(FAssetInfo& AssetInfo);
     
     static constexpr uint32 Version = 1;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.h
@@ -36,7 +36,7 @@ public:
 
     void StartPIE();
     void StartSkeletalMeshViewer(FName SkeletalMeshName, UAnimationAsset* AnimAsset);
-    void StartParticleViewer(FName ParticleName, UParticleSystem* ParticleSystem);
+    void StartParticleViewer(FName ParticleName);
 
     void StartPhysicsAssetViewer(FName PreviewMeshKey, FName PhysicsAssetName);
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAcceleration.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAcceleration.cpp
@@ -31,3 +31,10 @@ void UParticleModuleAcceleration::FinalUpdate(FParticleEmitterInstance* Owner, i
 
     END_UPDATE_LOOP
 }
+
+void UParticleModuleAcceleration::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << Acceleration;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAcceleration.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAcceleration.h
@@ -12,5 +12,7 @@ public:
     virtual void FinalUpdate(FParticleEmitterInstance* Owner, int32 Offset, float DeltaTime) override;
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, FVector, Acceleration)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAccelerationBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAccelerationBase.cpp
@@ -8,3 +8,10 @@ void UParticleModuleAccelerationBase::DisplayProperty()
         Property->DisplayInImGui(this);
     }
 }
+
+void UParticleModuleAccelerationBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bInWorldSpace << bApplyOwnerScale;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAccelerationBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Acceleration/ParticleModuleAccelerationBase.h
@@ -11,5 +11,7 @@ public:
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bInWorldSpace)
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bApplyOwnerScale)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorBase.cpp
@@ -30,3 +30,10 @@ void UParticleModuleColorBase::DisplayProperty()
         ImGui::PopID();
     }
 }
+
+void UParticleModuleColorBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << StartColor << StartAlpha;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorBase.h
@@ -6,6 +6,7 @@
 class UParticleModuleColorBase : public UParticleModule
 {
     DECLARE_CLASS(UParticleModuleColorBase, UParticleModule)
+    
 public:
     UParticleModuleColorBase();
 
@@ -15,8 +16,9 @@ public:
     // Initial Alpha : When particle is spawn
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionFloat, StartAlpha)
 
-public:
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
 
     virtual void DisplayProperty() override;
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorOverLife.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorOverLife.cpp
@@ -56,3 +56,10 @@ void UParticleModuleColorOverLife::DisplayProperty()
         ImGui::PopID();
     }
 }
+
+void UParticleModuleColorOverLife::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << ColorOverLife << AlphaOverLife;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorOverLife.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Color/ParticleModuleColorOverLife.h
@@ -23,4 +23,6 @@ public:
     virtual void Update(FParticleEmitterInstance* Owner, int32 Offset, float DeltaTime) override;
 
     virtual void DisplayProperty() override;
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.cpp
@@ -48,3 +48,10 @@ void UParticleModuleLocation::Spawn(FParticleEmitterInstance* Owner, int32 Offse
 
     ParticleBase->Location = Location;
 }
+
+void UParticleModuleLocation::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << StartLocation << LocationOffset;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocation.h
@@ -15,5 +15,7 @@ public:
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionVector, StartLocation)
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionVector, LocationOffset)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocationBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocationBase.cpp
@@ -8,3 +8,10 @@ void UParticleModuleLocationBase::DisplayProperty()
         Property->DisplayInImGui(this);
     }
 }
+
+void UParticleModuleLocationBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bInWorldSpace << bApplyEmitterLocation;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocationBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModuleLocationBase.h
@@ -13,5 +13,7 @@ public:
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bInWorldSpace)
     // Emitter 위치를 시작 위치에 더할지 여부
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bApplyEmitterLocation)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Modules/ParticleModuleLifeTime.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Modules/ParticleModuleLifeTime.cpp
@@ -39,3 +39,10 @@ void UParticleModuleLifeTime::DisplayProperty()
         ImGui::PopID();
     }
 }
+
+void UParticleModuleLifeTime::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << LifeSpan;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Modules/ParticleModuleLifeTime.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Modules/ParticleModuleLifeTime.h
@@ -20,4 +20,6 @@ public:
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
 
     virtual void DisplayProperty() override;
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.cpp
@@ -4,15 +4,16 @@
 #include "ParticleLODLevel.h"
 #include "ParticleModule.h"
 #include "ParticleModuleRequired.h"
+#include "Container/ArrayHelper.h"
 #include "Spawn/ParticleModuleSpawn.h"
 
 UParticleEmitter::UParticleEmitter()
 {
-    UParticleLODLevel* NewParticleLODLevel = new UParticleLODLevel(); // LOD 하나만 쓰기 때문에 일단 이렇게 생성
+    UParticleLODLevel* NewParticleLODLevel = FObjectFactory::ConstructObject<UParticleLODLevel>(this); // LOD 하나만 쓰기 때문에 일단 이렇게 생성
     LODLevels.Add(NewParticleLODLevel);
 }
 
-void UParticleEmitter::CacheEmitterModuleInfo()
+void UParticleEmitter::CacheEmitterModuleInfo() // Not used
 {
     // TODO: 언리얼 코드 참고
     
@@ -51,4 +52,18 @@ UParticleLODLevel* UParticleEmitter::GetLODLevel(int32 LODIndex) const
         return LODLevels[LODIndex];
     }
     return nullptr;
+}
+
+void UParticleEmitter::SerializeAsset(FArchive& Ar)
+{
+    uint8 Type = static_cast<uint8>(EmitterType);
+
+    Ar << PeakActiveParticles << ParticleSize << Type;
+
+    if (Ar.IsLoading())
+    {
+        EmitterType = static_cast<EDynamicEmitterType>(Type);
+    }
+
+    FArrayHelper::SerializePtrAsset(Ar, LODLevels, this);
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
@@ -6,23 +6,6 @@
 class UParticleModule;
 class UParticleLODLevel;
 
-enum class EParticleBurstMethod : uint8
-{
-    EPBM_Instant,
-    EPBM_Interpolated,
-    EPBM_MAX,
-};
-
-enum EParticleSubUVInterpMethod : int
-{
-    PSUVIM_None,
-    PSUVIM_Linear,
-    PSUVIM_Linear_Blend,
-    PSUVIM_Random,
-    PSUVIM_Random_Blend,
-    PSUVIM_MAX,
-};
-
 class UParticleEmitter : public UObject
 {
     DECLARE_CLASS(UParticleEmitter, UObject)
@@ -36,14 +19,16 @@ public:
     virtual void DisplayProperty() override;
 
     TArray<UParticleLODLevel*> GetLODLevels() const { return LODLevels; }
-    TMap<UParticleModule*, uint32> ModuleOffsetMap;
+    TMap<UParticleModule*, uint32> ModuleOffsetMap; // Not used
     UParticleLODLevel* GetLODLevel(int32 LODIndex) const;
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 
 public:
     UPROPERTY_WITH_FLAGS(EditAnywhere, FName, EmitterName, = "Default")
     int32 PeakActiveParticles = 0;
 
-    // Below is information udpated by calling CacheEmitterModuleInfo
+    // Below is information updated by calling CacheEmitterModuleInfo
     
     int32 ParticleSize;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
@@ -30,6 +30,8 @@ public:
     void AddModule(UParticleModule* NewModule) { Modules.Add(NewModule); }
     void DeleteModule(UParticleModule* DeleteModule) { Modules.Remove(DeleteModule); }
 
+    virtual void SerializeAsset(FArchive& Ar) override;
+
 private:
     TArray<UParticleModule*> Modules;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.cpp
@@ -21,3 +21,9 @@ int32 UParticleModule::GetInstancePayloadSize() const
 {
     return int32();
 }
+
+void UParticleModule::SerializeAsset(FArchive& Ar)
+{
+    Ar << ModuleName << bSpawnModule << bUpdateModule << bFinalUpdateModule << bEnabled
+       << ModulePayloadOffset << InstancePayloadOffset;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModule.h
@@ -36,7 +36,7 @@ public:
     UParticleModule() = default;
     virtual ~UParticleModule() override = default;
 
-    virtual void DisplayProperty() override {};
+    virtual void DisplayProperty() override {}
 
     FName ModuleName;
     
@@ -81,4 +81,6 @@ public:
 
     virtual int32 GetInstancePayloadSize() const;
     void SetInstancePayloadOffset(int32 Size) { InstancePayloadOffset = Size; }
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModuleRequired.h
@@ -3,7 +3,7 @@
 #include "ParticleModule.h"
 #include "Components/Material/Material.h"
 
-enum EParticleSortMode : int
+enum class EParticleSortMode : uint8
 {
     PSORTMODE_None,
     PSORTMODE_ViewProjDepth,
@@ -24,8 +24,6 @@ struct FParticleRequiredModule
     uint8 bCutoutTextureIsValid : 1;
     uint8 bUseVelocityForMotionBlur : 1;
 };
-
-struct FParticleRequiredModule;
 
 class UParticleModuleRequired : public UParticleModule
 {
@@ -92,4 +90,6 @@ public:
     ID3D11ShaderResourceView* CachedBoundingGeometrySRV = nullptr;
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bUseVelocityForMotionBlur)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSpriteEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSpriteEmitter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-enum EParticleScreenAlignment : int
+enum class EParticleScreenAlignment : uint8
 {
     PSA_FacingCameraPosition,
     PSA_Square,

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.cpp
@@ -1,1 +1,9 @@
 ﻿#include "ParticleSystem.h"
+
+#include "Particles/ParticleEmitter.h"
+#include "Container/ArrayHelper.h"
+
+void UParticleSystem::SerializeAsset(FArchive& Ar)
+{
+    FArrayHelper::SerializePtrAsset(Ar, Emitters);
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
@@ -16,7 +16,7 @@ public:
 
 class UParticleSystem : public UFXSystemAsset
 {
-    DECLARE_CLASS(UParticleSystem, UObject)
+    DECLARE_CLASS(UParticleSystem, UFXSystemAsset)
 
 public:
     UParticleSystem() = default;
@@ -28,6 +28,8 @@ public:
 
     float GetMacroUVRadius() const { return MacroUVRadius; }
     FVector GetMacroUVPosition() const { return MacroUVPosition; }
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 
 private:
     TArray<UParticleEmitter*> Emitters;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystemComponent.h
@@ -48,13 +48,14 @@ public:
     FParticleDynamicData* GetParticleDynamicData() const { return ParticleDynamicData; }
     
     void ReBuildInstancesMemoryLayout();
+    
 public:
     float AccumTickTime;
     
 private:
     TArray<FParticleEmitterInstance*> EmitterInstances;
 
-    UPROPERTY_WITH_FLAGS(EditAnywhere,UParticleSystem*, Template)
+    UPROPERTY_WITH_FLAGS(EditAnywhere, UParticleSystem*, Template)
 
     TArray<FDynamicEmitterDataBase*> EmitterRenderData;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSize.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSize.cpp
@@ -53,3 +53,10 @@ void UParticleModuleSize::Spawn(FParticleEmitterInstance* Owner, int32 Offset, f
 
     ParticleBase->BaseSize = InitialSize;
 }
+
+void UParticleModuleSize::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << StartSize;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSize.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSize.h
@@ -13,4 +13,6 @@ public:
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionVector, StartSize)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSizeBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSizeBase.cpp
@@ -10,3 +10,10 @@ void UParticleModuleSizeBase::DisplayProperty()
         ImGui::PopID();
     }
 }
+
+void UParticleModuleSizeBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bUseUniformSize;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSizeBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Size/ParticleModuleSizeBase.h
@@ -10,4 +10,6 @@ public:
     virtual void DisplayProperty() override;
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bUseUniformSize)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawn.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawn.cpp
@@ -39,3 +39,10 @@ void UParticleModuleSpawn::GetSpawnRate(float& MinSpawnRate, float& MaxSpawnRate
     MinSpawnRate = MinSpawn * MinScale;
     MaxSpawnRate = MaxSpawn * MaxScale;
 }
+
+void UParticleModuleSpawn::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << Rate << RateScale << BurstTime << BurstCount;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawn.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawn.h
@@ -34,4 +34,6 @@ public:
     virtual void GetSpawnRate(float& MinSpawnRate, float& MaxSpawnRate) override;
     
     //~ End UParticleModuleSpawnBase Interface
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawnBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawnBase.cpp
@@ -8,3 +8,10 @@ void UParticleModuleSpawnBase::DisplayProperty()
         Property->DisplayInImGui(this);
     }
 }
+
+void UParticleModuleSpawnBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bProcessSpawnRate << bProcessBurstList;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawnBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModuleSpawnBase.h
@@ -95,4 +95,6 @@ public:
 	//  *	@return	int32			The maximum burst count
 	//  */
 	// virtual int32 GetMaximumBurstCount() { return 0; }
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/SubUV/ParticleModuleSubUV.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/SubUV/ParticleModuleSubUV.cpp
@@ -114,3 +114,10 @@ int UParticleModuleSubUV::DetermineImageIndex(
     SubUVPayload.ImageIndex = ImageIndex;
     return ImageIndex;
 }
+
+void UParticleModuleSubUV::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << SubImageIndex;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/SubUV/ParticleModuleSubUV.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/SubUV/ParticleModuleSubUV.h
@@ -31,6 +31,8 @@ public:
         DeltaTime
     );
 
+    virtual void SerializeAsset(FArchive& Ar) override;
+
 private:
     FFullSubUVPayload FullSubUVPayload;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.cpp
@@ -50,3 +50,10 @@ void UParticleModuleVelocity::Spawn(FParticleEmitterInstance* Owner, int32 Offse
 
     ParticleBase->BaseVelocity = Velocity;
 }
+
+void UParticleModuleVelocity::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << StartVelocity << StartVelocityRadial;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocity.h
@@ -20,4 +20,6 @@ public:
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionVector, StartVelocity)
     UPROPERTY_WITH_FLAGS(EditAnywhere, FDistributionFloat, StartVelocityRadial)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityBase.cpp
@@ -8,3 +8,10 @@ void UParticleModuleVelocityBase::DisplayProperty()
         Property->DisplayInImGui(this);
     }
 }
+
+void UParticleModuleVelocityBase::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bInWorldSpace << bApplyOwnerScale;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityBase.h
@@ -11,4 +11,6 @@ public:
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bInWorldSpace)
     UPROPERTY_WITH_FLAGS(EditAnywhere, bool, bApplyOwnerScale)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.cpp
@@ -95,3 +95,10 @@ void UParticleModuleVelocityOverLife::Update(FParticleEmitterInstance* Owner, in
             
     END_UPDATE_LOOP
 }
+
+void UParticleModuleVelocityOverLife::SerializeAsset(FArchive& Ar)
+{
+    Super::SerializeAsset(Ar);
+
+    Ar << bUseConstantChange << bUseVelocityCurve << CurveScale << StartVelocity << EndVelocity;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModuleVelocityOverLife.h
@@ -26,5 +26,7 @@ public:
 
     UPROPERTY_WITH_FLAGS(EditAnywhere, FVector, StartVelocity)
     UPROPERTY_WITH_FLAGS(EditAnywhere, FVector, EndVelocity)
+
+    virtual void SerializeAsset(FArchive& Ar) override;
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Particles/ParticleSystemRender.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Particles/ParticleSystemRender.cpp
@@ -74,19 +74,19 @@ void FDynamicSpriteEmitterReplayDataBase::Serialize(FArchive& Ar)
 
 void FDynamicSpriteEmitterDataBase::SortSpriteParticles(int32 SortMode, bool bLocalSpace, int32 ParticleCount, const uint8* ParticleData, int32 ParticleStride, const uint16* ParticleIndices, const FMatrix& LocalToWorld) const
 {
-    if (SortMode == PSORTMODE_ViewProjDepth)
+    if (SortMode == static_cast<int32>(EParticleSortMode::PSORTMODE_ViewProjDepth))
 	{
 
 	}
-	else if (SortMode == PSORTMODE_DistanceToView)
+	else if (SortMode == static_cast<int32>(EParticleSortMode::PSORTMODE_DistanceToView))
 	{
 
 	}
-	else if (SortMode == PSORTMODE_Age_OldestFirst)
+	else if (SortMode == static_cast<int32>(EParticleSortMode::PSORTMODE_Age_OldestFirst))
 	{
 
 	}
-	else if (SortMode == PSORTMODE_Age_NewestFirst)
+	else if (SortMode == static_cast<int32>(EParticleSortMode::PSORTMODE_Age_NewestFirst))
 	{
 
 	}
@@ -97,7 +97,9 @@ FVector2D GetParticleSize(const FBaseParticle& Particle, const FDynamicSpriteEmi
     FVector2D Size;
     Size.X = FMath::Abs(Particle.Size.X * Source.Scale.X);
     Size.Y = FMath::Abs(Particle.Size.Y * Source.Scale.Y);
-    if (Source.ScreenAlignment == PSA_Square || Source.ScreenAlignment == PSA_FacingCameraPosition || Source.ScreenAlignment == PSA_FacingCameraDistanceBlend)
+    if (Source.ScreenAlignment == static_cast<uint8>(EParticleScreenAlignment::PSA_Square) ||
+        Source.ScreenAlignment == static_cast<uint8>(EParticleScreenAlignment::PSA_FacingCameraPosition) ||
+        Source.ScreenAlignment == static_cast<uint8>(EParticleScreenAlignment::PSA_FacingCameraDistanceBlend))
     {
         Size.Y = Size.X;
     }


### PR DESCRIPTION
## 주요 변경사항

* 파티클 Save, Load 지원
* 포인터 타입을 담고있는 TArray를 FArchive를 통해 저장할 때의 로직 개선
  * 단순 타입을 통해 비교하는 것이 아닌 실제 객체의 타입 정보를 기반으로 가상 함수가 제대로 호출되도록 개선
  * TODO: UObject가 아닌 다른 클래스 및 구조체에 대해서는 지원 안되므로 개선 필요
